### PR TITLE
(feature request) Add docstrings for cleaner output

### DIFF
--- a/noseOfYeti/specs/general_tokeniser_test.py
+++ b/noseOfYeti/specs/general_tokeniser_test.py
@@ -12,19 +12,29 @@ class Test_Tokeniser(object):
 
     def test_gives_describes_noy_specific_attributes(self):
         imports = determine_imports(with_default_imports=False)
-        tok = Tokeniser(import_tokens = imports)
-        (tok, 'describe "Something testable"') |should| result_in(
-        '''
-        class TestSomethingTestable (object ):pass
+        tok = Tokeniser(import_tokens=imports)
+        tok_str = 'describe "Something so_very() testable"'
+        expected = (
+            '''
+            class TestSomethingSoVeryTestable (object ):
+                """Something so_very() testable"""
+                pass
 
-        TestSomethingTestable .is_noy_spec =True
-        '''
-        )
+            TestSomethingSoVeryTestable .is_noy_spec =True
+            ''')
+        (tok, tok_str) |should| result_in(expected)
 
     def test_is_possible_to_turn_off_attributes(self):
         imports = determine_imports(with_default_imports=False)
         tok = Tokeniser(import_tokens=imports, with_describe_attrs=False)
-        (tok, 'describe "Something testable"') |should| result_in('class TestSomethingTestable (object ):pass')
+        tok_str = 'describe "Something so_very() testable"'
+        expected = (
+            '''
+            class TestSomethingSoVeryTestable (object ):
+                """Something so_very() testable"""
+                pass
+            ''')
+        (tok, tok_str) |should| result_in(expected)
 
     def test_no_newline_in_default_imports(self):
         tok = Tokeniser(import_tokens=determine_imports())
@@ -51,4 +61,3 @@ class Test_Tokeniser(object):
         imports = determine_imports()
         tok = Tokeniser(import_tokens=imports)
         (tok, '') |should| result_in('')
-

--- a/noseOfYeti/tokeniser/containers.py
+++ b/noseOfYeti/tokeniser/containers.py
@@ -133,6 +133,14 @@ class Group(object):
             self._name = acceptable(value, True)
 
     @property
+    def comment(self):
+        """Compose a comment from the group's english."""
+        quoteless_en = self.english.lstrip('\'"').rstrip('\'"')
+        if not self.parent or not self.parent.english:
+            return quoteless_en
+        return '%s %s' % (self.parent.comment, quoteless_en)
+
+    @property
     def starting_signature(self):
         """Determine if this group is starting itself or anything belonging to it"""
         return self.starting_group or self.starting_single
@@ -182,4 +190,3 @@ class Group(object):
             self.kls = name
         else:
             self.kls += name
-

--- a/noseOfYeti/tokeniser/tokens.py
+++ b/noseOfYeti/tokeniser/tokens.py
@@ -1,4 +1,4 @@
-from tokenize import NAME, OP, INDENT, NEWLINE, STRING
+from tokenize import COMMENT, NAME, OP, INDENT, NEWLINE, STRING
 from tokenize import generate_tokens
 
 import six
@@ -77,6 +77,19 @@ class Tokens(object):
             ]
         )
         return lst
+
+    def make_comment(self, comment):
+        if not comment:
+            return
+        return [
+            (NEWLINE, '\n'),
+            (INDENT, '    '),
+            (COMMENT, '"""'),
+            (COMMENT, comment),
+            (COMMENT, '"""'),
+            (NEWLINE, '\n'),
+            (INDENT, '    '),
+        ]
 
     def make_describe(self, kls, name):
         lst = [ (NAME, 'class')
@@ -187,4 +200,3 @@ class Tokens(object):
 
     def wrap_before_each(self, class_name):
         return self.wrap_setup(class_name, "before_each")
-

--- a/noseOfYeti/tokeniser/tracker.py
+++ b/noseOfYeti/tokeniser/tracker.py
@@ -339,10 +339,6 @@ class Tracker(object):
         # Make sure pass not added to group again
         self.groups.empty = False
 
-        # Remove existing newline/indentation
-        while self.result[-1][0] in (INDENT, NEWLINE):
-            self.result.pop()
-
         # Add pass and indentation
         self.add_tokens(
             [ (NAME, 'pass')
@@ -377,10 +373,12 @@ class Tracker(object):
         """Add the tokens for the group signature"""
         kls = self.groups.super_kls
         name = self.groups.kls_name
+        comment = self.groups.comment
 
         # Reset indentation to beginning and add signature
         self.reset_indentation('')
         self.result.extend(self.tokens.make_describe(kls, name))
+        self.result.extend(self.tokens.make_comment(comment))
 
         # Add pass if necessary
         if with_pass:
@@ -511,4 +509,3 @@ class Tracker(object):
 
         value = self.indent_type * last_indent
         return tokenum, value
-


### PR DESCRIPTION
When using nosetests and `--with-spec`, the output created from the
generated code can be difficult to read.

Example:

```
describe TestCase, 'fetch_sub_action()':

    describe 'using wl_basic':

        describe 'when already subscribed to a better hosing plan'

            it 'returns a downgrade link':
                pass
```

Spits out:

> Fetch sub action_ using wl basic_ when already subscribed to a better hosting plan
> - returns a downgrade link

But using the english to generate docstrings, it can be:

> fetch_sub_action() using wl_basic when already subscribed to a better hosting plan
> - returns a downgrade link

I've added a bit of code to this issue as a proof of concept.
