### PR TITLE
Include example in sdist to fix tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ include = [
     "/test.sh",
     "/run.sh",
     "/pytest.ini",
+    "/example/*",
     "/tests/**",
     "/tools/bootstrap_venvstarter.py",
     "/tools/requirements.dev.txt",


### PR DESCRIPTION
Include the example files in the source distribuation, in order to fix the following test failure:

```
_______________________________________ Test_RegisteringCodec.test_can_correctly_translate_file _______________________________________
tests/test_spec_codec.py:133: in test_can_correctly_translate_file
    with open(os.path.join(example_dir, "test.py")) as fle:
E   FileNotFoundError: [Errno 2] No such file or directory: '/tmp/portage/dev-python/noseofyeti-2.4.6/work/noseofyeti-2.4.6/tests/../ex
ample/test.py'
        self       = <tests.test_spec_codec.Test_RegisteringCodec object at 0x0000565218fa6f70>
```