### PR TITLE
Fix pypy3 test failure due to error message mismatch

### DIFF
--- a/tests/test_spec_codec.py
+++ b/tests/test_spec_codec.py
@@ -117,7 +117,7 @@ class Test_RegisteringCodec:
             env={"NOSE_OF_YETI_BLACK_COMPAT": "false"},
             status=1,
         )
-        expected_output = "SyntaxError: unknown encoding: spec"
+        expected_output = "SyntaxError: [Uu]nknown encoding: spec"
         pytest.helpers.assert_regex_lines(output.split("\n")[-1], expected_output)
 
     def test_registering_codec_doesnt_lead_to_error(self, directory):


### PR DESCRIPTION
Update the expected error message to account for capitalization difference in PyPy3.10.  This fixes the following test failure:

```pytb
___________________________________ Test_RegisteringCodec.test_not_registering_codec_leads_to_error ___________________________________
tests/test_spec_codec.py:121: in test_not_registering_codec_leads_to_error
    pytest.helpers.assert_regex_lines(output.split("\n")[-1], expected_output)
E   Failed: line 0 does not match. Wanted:
E   SyntaxError: unknown encoding: spec
E
E   Got:
E   SyntaxError: Unknown encoding: spec
-------------------------------------------------------- Captured stdout call ---------------------------------------------------------
the process output:
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/tmp/pytest-of-mgorny/pytest-6/registering_codec0/test_code.py", line 0
    # coding: spec
SyntaxError: Unknown encoding: spec
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
GOT LINES
=========
SyntaxError: Unknown encoding: spec

WANT LINES
==========
SyntaxError: unknown encoding: spec
```